### PR TITLE
fix TypeError: unsupported operand type(s) for /: 'str' and 'int'

### DIFF
--- a/somatic_llr_filter.py
+++ b/somatic_llr_filter.py
@@ -298,8 +298,14 @@ def main(args_input = sys.argv[1:]):
 
         #TODO parse out per alt, retrieve calls
         for i in range(1,(len(alts)+1)):  #right now, this will only ever be one, due to above check.  Could be expanded to support multiple alleles - see above
-            normal_var = ad_nrm[i]
-            tumor_var = ad_tum[i]
+            if(ad_nrm == "NA"):
+		normal_var = "NA"
+	    else:
+		normal_var = ad_nrm[i]
+	    if(ad_tum == "NA"):
+		tumor_var = "NA"
+	    else:
+		tumor_var = ad_tum[i]
             
             #if neither has any depth or vals or missing, then fail this up front
             if missingVals([normal_var,tumor_var,tumor_depth,normal_depth]) or (tumor_depth + normal_depth == 0):


### PR DESCRIPTION
Error occurs because normal/tumor_var are set to NA here:

https://github.com/genome/docker-somatic-llr-filter/blob/97b1e7dff44662cb557793f9b4db73623f43e8d9/somatic_llr_filter.py#L278

and the A of the NA is then extracted here:
https://github.com/genome/docker-somatic-llr-filter/blob/97b1e7dff44662cb557793f9b4db73623f43e8d9/somatic_llr_filter.py#L300

for cases with missing values